### PR TITLE
Ho concrete func calls

### DIFF
--- a/sturdy-wasm/src/Interp/SharedHO/ConcreteInterpreter.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/ConcreteInterpreter.hs
@@ -23,25 +23,29 @@ import Interp.SharedHO.Data.Types
 import Interp.SharedHO.Data.ToyState
 import Interp.SharedHO.GenericInterpreter
 
+data Interrupt = Error String | Branching Int | Returning
+
 newtype Concrete a = Concrete
-    { runConcrete :: ExceptT (Either String Int) (State (ToyState Value)) a }
+    { runConcrete :: ExceptT Interrupt (ReaderT ToyModule (State
+        (ToyState Value))) a }
     deriving (Functor, Applicative, Monad, MonadState (ToyState Value),
-        MonadError (Either String Int))
+        MonadError Interrupt, MonadReader ToyModule)
 
 instance Interp Concrete Value where
     pushBlock _ _ br adv = do
         st1 <- get
         put $ set stack [] st1
         catchError adv $ \e -> case e of
-            Right n  -> if n <= 0
+            Branching n -> if n <= 0
                 then br
-                else throwError $ Right $ n - 1
-            Left msg -> throwError $ Left msg
+                else throwError $ Branching $ n - 1
+            Error msg   -> throwError $ Error msg
+            Returning   -> throwError $ Returning
         st2 <- get
         v <- pop
         put $ set stack (v : view stack st1) st2
 
-    popBlock n = throwError $ Right n
+    popBlock n = throwError $ Branching n
 
     const = return
 
@@ -61,7 +65,7 @@ instance Interp Concrete Value where
         st <- get
         case M.lookup var (view variables st) of
             Just v  -> return v
-            Nothing -> throwError $ Left $ "Var " ++ var ++ " not in scope."
+            Nothing -> throwError $ Error $ "Var " ++ var ++ " not in scope."
 
     push v = modify $ over stack (v:)
 
@@ -71,13 +75,33 @@ instance Interp Concrete Value where
             v:_ -> do
                 modify $ over stack tail
                 return v
-            []  -> throwError $ Left $ "Tried to pop value from empty stack."
+            []  -> throwError $ Error $ "Tried to pop value from empty stack."
+
+    lookupFunc name = do
+        mdl <- ask
+        case M.lookup name mdl of
+            Just f  -> return f
+            Nothing -> throwError $ Error $ "No func " ++ name ++ " in module."
+
+    call enter = do
+        st <- get
+        put emptyToySt
+        catchError enter $ \e -> case e of
+            Returning   -> return ()
+            Branching _ -> throwError $ Error $ "Func-level branch."
+            Error msg   -> throwError $ Error msg
+        v <- pop
+        put st
+        push v
+
+    return_ = throwError Returning
 
 instance Fix (Concrete ()) where
     fix f = f (fix f)
 
-run :: Expr -> (Either (Either String Int) (), ToyState Value)
+run :: Expr -> (Either Interrupt (), ToyState Value)
 run e = runState
-            (runExceptT
-                (runConcrete
-                    ((interp :: Expr -> Concrete ()) e))) emptyToySt
+            (runReaderT
+                (runExceptT
+                    (runConcrete
+                        ((interp :: Expr -> Concrete ()) e))) M.empty) emptyToySt

--- a/sturdy-wasm/src/Interp/SharedHO/ConcreteInterpreter.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/ConcreteInterpreter.hs
@@ -82,16 +82,16 @@ instance Interp Concrete Value where
     call name = do
         fs <- ask
         case M.lookup name fs of
-            Just f  -> catchError f $ \e -> case e of
-                Returning   -> return ()
-                Branching _ -> throwError $ Error $ "Func-level branch."
-                Error msg   -> throwError $ Error msg
+            Just f  -> f
             Nothing -> throwError $ Error $ "No func " ++ name ++ " in module."
 
     closure m = do
         st <- get
         put emptyToySt
-        m
+        catchError m $ \e -> case e of
+            Returning   -> return ()
+            Branching _ -> throwError $ Error $ "Func-level branch."
+            Error msg   -> throwError $ Error msg
         v <- pop
         put st
         push v

--- a/sturdy-wasm/src/Interp/SharedHO/Data/Types.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/Data/Types.hs
@@ -17,6 +17,12 @@ data Value = Value {
 instance Show Value where
     show (Value t v) = show t ++ ":" ++ show v
 
+instance ToBool Integer where
+    toBool = (/=) 0
+
+instance FromBool Integer where
+    fromBool b = if b then 1 else 0
+
 instance ToBool Value where
     toBool = ((/=) 0) . getVal
 

--- a/sturdy-wasm/src/Interp/SharedHO/FuncPrograms.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/FuncPrograms.hs
@@ -42,6 +42,10 @@ gaussSum = Func [("n", I32)] I32 $
                 , Add
                 , Call "gauss"
                 , Add
+                , Return
+                , Add
+                , Add
+                , Add
                 ])
         ]
 
@@ -51,3 +55,5 @@ generalMdl = [ ("add", addition)
              , ("gauss", gaussSum)
              , ("lt", lessThan)
              ]
+
+runMdl = runFunc generalMdl

--- a/sturdy-wasm/src/Interp/SharedHO/FuncPrograms.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/FuncPrograms.hs
@@ -1,0 +1,53 @@
+module Interp.SharedHO.FuncPrograms
+where
+
+import Interp.SharedHO.GenericInterpreter
+import Interp.SharedHO.ConcreteInterpreter
+import Interp.SharedHO.Data.Types
+
+i32Val = Value I32
+i64Val = Value I64
+
+addition :: Func
+addition = Func [("x", I32), ("y", I32)] I32 $
+    Seq [Var "x", Var "y", Add]
+
+lessThan :: Func
+lessThan = Func [("x", I32), ("y", I32)] I32 $
+    Seq [Var "x", Var "y", Lt]
+
+ifStatement :: Func
+ifStatement = Func [("x", I32)] I32 $
+    Seq
+        [ Const (i32Val 0)
+        , Assign "y"
+        , Var "x"
+        , If I32
+             (Seq [Const (i32Val 2), Assign "y", Const (i32Val 0)])
+             (Seq [Const (i32Val 3), Assign "y", Const (i32Val 0)])
+        , Var "y"
+        ]
+
+gaussSum :: Func
+gaussSum = Func [("n", I32)] I32 $
+    Seq
+        [ Var "n"
+        , Eqz
+        , If I32
+            (Const (i32Val 0))
+            (Seq
+                [ Var "n"
+                , Var "n"
+                , Const (i32Val (-1))
+                , Add
+                , Call "gauss"
+                , Add
+                ])
+        ]
+
+generalMdl :: ToyModule
+generalMdl = [ ("add", addition)
+             , ("ifStat", ifStatement)
+             , ("gauss", gaussSum)
+             , ("lt", lessThan)
+             ]

--- a/sturdy-wasm/src/Interp/SharedHO/GenericInterpreter.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/GenericInterpreter.hs
@@ -116,13 +116,16 @@ interp expr = case expr of
 
 interpFunc :: (Interp m v, Fix (m ())) => ToyModule -> String -> [v]-> m ()
 interpFunc mdl startName vs =
-    let popAssign var = do { v <- pop; assign var v }
+    let getArgs f = mapM (\(var, _) -> do { v <- pop; return (var, v) })
+            (funcParams f)
+
+        assignArgs = mapM_ (\(var, v) -> assign var v)
 
         firstCall name f = fix $ \recCall -> do
                 assignFunc name recCall $ do
-                    args <- mapM (\(var, _) -> do { v <- pop; return (var, v) }) (funcParams f)
+                    args <- getArgs f
                     closure $ do
-                        mapM_ (\(var, v) -> assign var v) args
+                        assignArgs args
                         interp $ funcBody f
 
         start = do


### PR DESCRIPTION
Implement function calls just for the concrete interpreter, but keeping in mind that the same generic code should also work for static analyses (hence, the use of fix and other complexities).