### PR TITLE
[WIP] Add function calls to type checker

### DIFF
--- a/sturdy-wasm/src/Interp/SharedHO/ConcreteInterpreter.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/ConcreteInterpreter.hs
@@ -84,7 +84,7 @@ instance Interp Concrete Value where
             Just f  -> f
             Nothing -> throwError $ Error $ "No func " ++ name ++ " in module."
 
-    closure m = do
+    closure _ m = do
         st <- get
         put emptyToySt
         catchError m $ \e -> case e of

--- a/sturdy-wasm/src/Interp/SharedHO/Exceptions.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/Exceptions.hs
@@ -18,6 +18,8 @@ data TException where
     -- |Takes the target depth and max depth
     InvalidDepth :: (Show a, Show b) => a -> b -> TException
 
+    NameError :: (Show a) => a -> TException
+
 
 instance Show TException where
     show (TypeMismatch expected actual) =
@@ -40,3 +42,5 @@ instance Show TException where
 
     show (InvalidDepth target max) =
         "Can't break " ++ show target ++ " (max " ++ show max ++ ")"
+
+    show (NameError name) = "'" ++ show name ++ "' is not defined"

--- a/sturdy-wasm/src/Interp/SharedHO/FuncPrograms.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/FuncPrograms.hs
@@ -5,6 +5,7 @@ import Interp.SharedHO.GenericInterpreter
 import Interp.SharedHO.ConcreteInterpreter
 import Interp.SharedHO.ReachingDefinitions
 import Interp.SharedHO.IntervalAnalysis
+import Interp.SharedHO.TypeChecker
 import qualified Interp.SharedHO.Data.RDSet as RD
 import qualified Interp.SharedHO.Data.Interval as Interval
 import Interp.SharedHO.Data.Types
@@ -102,3 +103,4 @@ generalMdl = [ ("add", addition)
 runMdl = runFunc generalMdl
 runMdlRD = runFuncRD generalMdl
 runMdlIA = runFuncIA generalMdl
+runMdlTC = runFuncTC generalMdl

--- a/sturdy-wasm/src/Interp/SharedHO/GenericInterpreter.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/GenericInterpreter.hs
@@ -57,7 +57,7 @@ class Monad m => Interp m v | m -> v where
     pop :: m v
     assignFunc :: String -> m () -> m () -> m ()
     call :: String -> m ()
-    closure :: m () -> m ()
+    closure :: Type -> m () -> m ()
     return_ :: m ()
 
 -- data FixType = LoopFix | FuncFix String
@@ -126,10 +126,10 @@ interpFunc mdl startName vs =
 
         assignArgs = mapM_ (\(var, v) -> assign var v)
 
-        firstCall name f = fix' $ \recCall -> do
+        firstCall name f = fix' $ \recCall ->
                 assignFunc name recCall $ do
                     args <- getArgs f
-                    closure $ do
+                    closure (funcRetType f) $ do
                         assignArgs args
                         interp $ funcBody f
 

--- a/sturdy-wasm/src/Interp/SharedHO/IntervalAnalysis.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/IntervalAnalysis.hs
@@ -105,7 +105,7 @@ instance Interp IAnalys (Interval (InfiniteNumber Value)) where
             Just f  -> f
             Nothing -> throwError $ Error $ "No func " ++ name ++ " in module."
 
-    closure m = do
+    closure _ m = do
         st <- get
         put emptyToySt
         catchError m $ \e -> case e of

--- a/sturdy-wasm/src/Interp/SharedHO/ReachingDefinitions.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/ReachingDefinitions.hs
@@ -95,7 +95,7 @@ instance Interp ReachDef (RD.Set Value) where
             Just f  -> f
             Nothing -> throwError $ Error $ "No func " ++ name ++ " in module."
 
-    closure m = do
+    closure _ m = do
         st <- get
         put emptyToySt
         catchError m $ \e -> case e of

--- a/sturdy-wasm/src/Interp/SharedHO/TypeChecker.hs
+++ b/sturdy-wasm/src/Interp/SharedHO/TypeChecker.hs
@@ -56,15 +56,33 @@ stackTyping' = checkType . stackTyping
 stack' :: Lens' TypeCheckState [CType]
 stack' = checkType . stack
 
+type CheckerFuncMap = M.Map String (TypeChecker ())
+
 newtype TypeChecker a = TypeChecker
-    { runTypeChecker :: ExceptT TException (ReaderT [Maybe Type] (State TypeCheckState)) a}
+    { runTypeChecker :: ExceptT TException (StateT CheckerFuncMap 
+        (ReaderT[Maybe Type] (State TypeCheckState))) a}
     deriving (Functor, Applicative, Monad, MonadReader [Maybe Type],
-        MonadState TypeCheckState, MonadError TException)
+        MonadState CheckerFuncMap, MonadError TException)
+
+checkStateLift :: State TypeCheckState a -> TypeChecker a
+checkStateLift m = TypeChecker . lift . lift $ lift m
+
+getSt :: TypeChecker TypeCheckState
+getSt = checkStateLift get
+
+getsSt :: (TypeCheckState -> a) -> TypeChecker a
+getsSt f = checkStateLift $ gets f
+
+putSt :: TypeCheckState -> TypeChecker ()
+putSt st = checkStateLift $ put st
+
+modifySt :: (TypeCheckState -> TypeCheckState) -> TypeChecker ()
+modifySt f = checkStateLift $ modify f
 
 instance Interp TypeChecker CType where
     pushBlock rty blockType _ adv = do
-        outerBlockState <- get
-        put $ set stack' [] outerBlockState
+        outerBlockState <- getSt
+        putSt $ set stack' [] outerBlockState
         if blockType == BackwardJump
             then local (Nothing :) adv
             else local (Just rty :) adv
@@ -72,11 +90,11 @@ instance Interp TypeChecker CType where
         case val of
             SomeT val' | val' /= rty -> throwError $ TypeMismatch rty val'
             _                        -> return ()
-        put $ over stack' (SomeT rty :) outerBlockState
+        putSt $ over stack' (SomeT rty :) outerBlockState
 
     popBlock n = do
         rtys <- asks (drop n)
-        st   <- get
+        st   <- getSt
         let stack'' = view stack' st
         if null rtys
             then throwError $ InvalidDepth n (length rtys)
@@ -86,11 +104,11 @@ instance Interp TypeChecker CType where
                     val <- pop
                     case (val, rty) of
                         (SomeT val', Just rty') | val' == rty' ->
-                            put $ over stack' tail st
-                        (AnyT, Just _) -> put $ over stack' tail st
+                            putSt $ over stack' tail st
+                        (AnyT, Just _) -> putSt $ over stack' tail st
                         _              -> throwError $ TypeMismatch rty stack''
-                modify (set stackTyping' Top)
-                modify (set stack' [])
+                modifySt (set stackTyping' Top)
+                modifySt (set stack' [])
 
     const = return . SomeT . getType
 
@@ -104,47 +122,97 @@ instance Interp TypeChecker CType where
     eqz _ = return $ SomeT I32
 
     if_ rty t f = do
-        st <- get
+        st <- getSt
         t
-        stack1 <- gets (view stack')
-        put st
+        stack1 <- getsSt (view stack')
+        putSt st
         f
-        stack2 <- gets (view stack')
+        stack2 <- getsSt (view stack')
         if head stack1 == rty && head stack2 == rty
-            then put $ over stack' (rty :) st
+            then putSt $ over stack' (rty :) st
             else throwError $ TypeMismatch (head stack1) (head stack2)
 
     assign var v = do
-        st <- get
+        st <- getSt
         let expected = M.lookup var $ view variables st
         case expected of
             Just t  -> when (t /= v) $ throwError $ InvalidAssignment v var t
-            Nothing -> put $ over variables (M.insert var v) st
+            Nothing -> putSt $ over variables (M.insert var v) st
 
     lookup var = do
-        st <- get
+        st <- getSt
         case M.lookup var (view variables st) of
             Just v  -> return v
             Nothing -> throwError $ NotInScope var
 
-    push v = modify $ over stack' (v :)
+    push v = modifySt $ over stack' (v :)
 
     pop = do
-        st <- get
+        st <- getSt
         case view stack' st of
             v : _ -> do
-                modify $ over stack' tail
+                modifySt $ over stack' tail
                 return v
             [] -> if view stackTyping' st == Top
                 then return AnyT
                 else throwError StackUnderflow
 
-instance Fix () TypeChecker where
-    fix _ f = let x = f x in x
+    assignFunc name f adv = do
+        modify (M.insert name f)
+        adv
 
-typecheck :: Expr -> (Either TException (), TypeCheckState)
-typecheck e = runState
-    (runReaderT
-        (runExceptT
-            (runTypeChecker
-                ((interp :: Expr -> TypeChecker ()) e))) []) emptyTypeCheckState
+    call name = do
+        fs <- get
+        case M.lookup name fs of
+            Just f  -> f
+            Nothing -> throwError $ NameError name
+
+    closure rty m = do
+        st <- getSt
+        putSt emptyTypeCheckState
+        m
+        v <- pop
+        when (v /= SomeT rty) $ throwError $ TypeMismatch rty v
+        putSt st
+        push v
+
+    return_ = do
+        blockCount <- asks length
+        popBlock $ blockCount - 1
+
+instance Fix () TypeChecker where
+    fix _ f = f (return ())
+
+runTC :: Expr -> (Either TException (), TypeCheckState)
+runTC e = do
+    let
+        ((result, _), st) = runState
+            (runReaderT
+                (runStateT
+                    (runExceptT
+                        (runTypeChecker ((interp :: Expr -> TypeChecker ()) e))
+                    )
+                    M.empty
+                )
+                []
+            )
+            emptyTypeCheckState
+
+    (result, st)
+
+runFuncTC :: ToyModule -> String -> [CType] -> (Either TException (), TypeCheckState)
+runFuncTC mdl name vs = do
+    let
+        ((result, _), st) = runState
+            (runReaderT
+                (runStateT
+                    (runExceptT
+                        (runTypeChecker ((interpFunc :: ToyModule -> String -> [CType] -> TypeChecker ()) mdl name vs))
+                    )
+                    M.empty
+                )
+                []
+            )
+            emptyTypeCheckState
+
+    (result, st)


### PR DESCRIPTION
Add necessary definitions for function calls.
- Function closures are modified to act as blocks with a single return type
- Functions are not reassigned, but are also not replaced with just their function type after the first execution

Note:
- The other interpreters do not handle closures as blocks, should I change this?